### PR TITLE
Fix default `shortcutsPath`

### DIFF
--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -68,7 +68,7 @@ in
       shortcutsPath = mkOption {
         type = types.str;
         internal = true;
-        default = "${cfg.steamHomeDir}/${cfg.userConfigDir}/shortcuts.vdf";
+        default = "${cfg.userConfigDir}/shortcuts.vdf";
       };
 
       # NOTE: This configuration is formatted for use with json2steamshortcut


### PR DESCRIPTION
On NixOS, I noticed that the VDF file was being created under /home/\<user\>/home/\<user\>/....

It seems the home path is repeated because it's already included in the default value for `userConfigDir`.